### PR TITLE
Add proper window state handling

### DIFF
--- a/options/options.js
+++ b/options/options.js
@@ -89,6 +89,13 @@ async function saveChanges(prefixId) {
     console.log('Save', prefixId, settings);
     await browser.storage.local.set(settings);
 
+	settings.per_window_toggles.forEach( t => {
+		t.enabled = settings.toggles[prefixId - 1].enabled;
+		if(!settings.toggles[prefixId - 1].enabled){
+			t.state = false;
+		}
+	});
+	
     // Let the toolbar button reflect the changes
     browser.extension.getBackgroundPage().updateButtonStatus();
 

--- a/options/options.js
+++ b/options/options.js
@@ -89,10 +89,10 @@ async function saveChanges(prefixId) {
     console.log('Save', prefixId, settings);
     await browser.storage.local.set(settings);
 
-	settings.per_window_toggles.forEach( t => {
-		t.enabled = settings.toggles[prefixId - 1].enabled;
+	browser.extension.getBackgroundPage().per_window_toggles.forEach( (toggs,key) => {
+		toggs[prefixId].enabled = settings.toggles[prefixId - 1].enabled;
 		if(!settings.toggles[prefixId - 1].enabled){
-			t.state = false;
+			toggs[prefixId].state = false;
 		}
 	});
 	

--- a/popup/popup.js
+++ b/popup/popup.js
@@ -9,7 +9,7 @@ async function documentLoaded() {
 
 
     const settings = await browser.storage.local.get();
-    const toggles = settings.per_window_toggles.get((await browser.windows.getLastFocused()).id);
+    const toggles = browser.extension.getBackgroundPage().per_window_toggles.get((await browser.windows.getLastFocused()).id);
     const type = settings.general.allowMultiple ? 'checkbox' : 'radio';
 
     for (let i = 0; i < toggles.length; i++) {

--- a/popup/popup.js
+++ b/popup/popup.js
@@ -8,8 +8,8 @@ async function documentLoaded() {
     })
 
 
-    const settings = await browser.storage.local.get(['toggles', 'general']);
-    const toggles = settings.per_window_toggles[settings.current_windowId];
+    const settings = await browser.storage.local.get();
+    const toggles = settings.per_window_toggles.get((await browser.windows.getLastFocused()).id);
     const type = settings.general.allowMultiple ? 'checkbox' : 'radio';
 
     for (let i = 0; i < toggles.length; i++) {

--- a/popup/popup.js
+++ b/popup/popup.js
@@ -9,7 +9,7 @@ async function documentLoaded() {
 
 
     const settings = await browser.storage.local.get(['toggles', 'general']);
-    const toggles = settings.toggles;
+    const toggles = settings.per_window_toggles[settings.current_windowId];
     const type = settings.general.allowMultiple ? 'checkbox' : 'radio';
 
     for (let i = 0; i < toggles.length; i++) {

--- a/uct-background.js
+++ b/uct-background.js
@@ -44,12 +44,12 @@ async function windowFocusChanged(windowId){
     let settings = await browser.storage.local.get();
     settings.current_windowId=windowId;
     await updateSettings(settings);
+	await updateButtonStatus();
 }
 
 
 async function main() {
     await initializeSettings();
-    await updateButtonStatus();
     await updateTitlePrefixes();
 
     // Always toggle style 1 on button click
@@ -86,10 +86,10 @@ async function updateButtonStatus() {
     let settings = await browser.storage.local.get('toggles');
 
     // Use reduce function on array to count all enabled toggles
-    let togglesEnabled = settings.toggles.reduce((count, toggle) => toggle.enabled ? count + 1 : count, 0);
+    let togglesEnabled = settings.per_window_toggles[settings.current_windowId].reduce((count, toggle) => toggle.enabled ? count + 1 : count, 0);
 
     if (togglesEnabled < 2) {
-        let toggle = settings.toggles[0];
+        let toggle = (settings.per_window_toggles[settings.current_windowId])[0];
         browser.browserAction.setTitle({
             title: `Turn ${toggle.name} ` + (toggle.state ? 'off' : 'on')
         });

--- a/uct-background.js
+++ b/uct-background.js
@@ -36,7 +36,13 @@ async function windowCreated(window){
 
 async function windowDestroyed(windowId){
     let settings = await browser.storage.local.get();
-    settings.per_window_toggles.delete(window.id);
+    settings.per_window_toggles.delete(windowId);
+    await updateSettings(settings);
+}
+
+async function windowFocusChanged(windowId){
+    let settings = await browser.storage.local.get();
+    settings.current_windowId=windowId;
     await updateSettings(settings);
 }
 
@@ -58,6 +64,7 @@ async function main() {
     // Proper window state handling
     browser.windows.onCreated.addListener(windowCreated);
     browser.windows.onRemoved.addListener(windowDestroyed);
+    browser.windows.onFocusChanged.addListener(windowFocusChanged);
     console.log('Init complete');
 }
 

--- a/uct-background.js
+++ b/uct-background.js
@@ -31,7 +31,11 @@ this.defaultSettings = {
 
 async function windowCreated(window){
     let settings = await browser.storage.local.get();
-    settings.per_window_toggles[window.id]=(settings.per_window_toggles[settings.current_windowId]);
+	if(!settings.current_windowId===undefined){
+		settings.per_window_toggles[window.id]=(settings.per_window_toggles[settings.current_windowId]);
+	} else {
+		settings.per_window_toggles[window.id]=defaultSettings.toggles;
+	}
     await updateSettings(settings);
 }
 

--- a/uct-background.js
+++ b/uct-background.js
@@ -41,7 +41,7 @@ async function windowCreated(window){
     let settings = await browser.storage.local.get();
 	let pwt;
 	if(lastId!==undefined){
-		pwt=settings.per_window_toggles.get(lastId);
+		pwt=structuredClone(settings.per_window_toggles.get(lastId));
 	} else {
 		pwt=structuredClone(defaultSettings.toggles);
 	}
@@ -195,40 +195,29 @@ async function updateTitlePrefixes() {
 async function userToggle(styleId, newState) {
     // Extract style number from end of string
     styleId = String(styleId).match(/[0-9]+$/);
-
+	let windowId = (await browser.windows.getCurrent()).id;
     let settings = await browser.storage.local.get();
     let hrState = 'off';
     let toggle = { name: 'all styles' }
-
-	if(
-		settings.per_window_toggles.get(
-			(await browser.windows.getCurrent()).id
-		)===undefined
-	){
-		settings.per_window_toggles.set(
-			(await browser.windows.getCurrent()).id,
-			structuredClone(defaultSettings.toggles)
-		);
-	}
 
     if (
 		styleId
 		&& !(
 				settings.per_window_toggles.get(
-					(await browser.windows.getCurrent()).id
+					windowId
 				)
 			)[styleId[0] - 1].enabled
 		) {
-        console.log('Style is disabled', (settings.per_window_toggles.get((await browser.windows.getCurrent()).id))[styleId[0] - 1]);
+        console.log('Style is disabled', (settings.per_window_toggles.get(windowId))[styleId[0] - 1]);
         return
     }
 
     // When only one option allowed or no valid style is selected, reset all others
     // Also do this when no valid style has been found
     if (!settings.general.allowMultiple || !styleId) {
-        for (let i = 0; i < (settings.per_window_toggles.get((await browser.windows.getCurrent()).id)).length; i++) {
+        for (let i = 0; i < (settings.per_window_toggles.get(windowId)).length; i++) {
             if (!styleId || styleId[0] - 1 != i){
-                (settings.per_window_toggles.get((await browser.windows.getCurrent()).id))[i].state = false;
+                (settings.per_window_toggles.get(windowId))[i].state = false;
 			}
         }
     }
@@ -237,12 +226,12 @@ async function userToggle(styleId, newState) {
     if (styleId) {
         styleId = styleId[0];
         // Invert toggle state or set requested state and save in settings
-        toggle = (settings.per_window_toggles.get((await browser.windows.getCurrent()).id))[styleId - 1];
+        toggle = (settings.per_window_toggles.get(windowId))[styleId - 1];
 
         if (typeof(newState) == 'undefined')
             newState = !toggle.state;
 
-        (settings.per_window_toggles.get((await browser.windows.getCurrent()).id))[styleId - 1].state = newState;
+        (settings.per_window_toggles.get(windowId))[styleId - 1].state = newState;
 
         if (newState)
             hrState = 'on';

--- a/uct-background.js
+++ b/uct-background.js
@@ -24,7 +24,20 @@ this.defaultSettings = {
         settingsVersion: 1.1,
         allowMultiple: false,
         notifyMe: true
-    }
+    },
+    per_window_toggles: new Map()
+}
+
+async function windowCreated(window){
+    let settings = await browser.storage.local.get();
+    settings.per_window_toggles[window.id]=defaultSettings.toggles;
+    await updateSettings(settings);
+}
+
+async function windowDestroyed(windowId){
+    let settings = await browser.storage.local.get();
+    settings.per_window_toggles.delete(window.id);
+    await updateSettings(settings);
 }
 
 
@@ -41,6 +54,10 @@ async function main() {
 
     // Trigger on registered hotkeys
     browser.commands.onCommand.addListener(userToggle);
+    
+    // Proper window state handling
+    browser.windows.onCreated.addListener(windowCreated);
+    browser.windows.onRemoved.addListener(windowDestroyed);
     console.log('Init complete');
 }
 


### PR DESCRIPTION
Right now window handling is incomplete: the state of toggles is global but the shortcuts and toolbar acts on the window state and does not change other windows. This manifests itself in the bug: if you try to toggle a switch in two windows, it will take 2 button presses to activate the style in second window.

I do not know about others but it seems to me that per-window handling is desired way of operation. Therefore this pull request makes the behaviour consistent with my idea.

1) Toggles are now explicitly stored with respect to window IDs.
2) Toggle states are reset to "off" upon browser start
3) Toggle states for the new windows are inherited from the last window active.


Please test it yourself, I did not (I have no desire to setup anything to debug it).